### PR TITLE
Fix deprecated Buffer usage warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ function equalFiles(pathA, pathB) {
     }
     var fdA = fs.openSync(pathA, 'r');
     var fdB = fs.openSync(pathB, 'r');
-    var bufA = new Buffer(BUF_SIZE);
-    var bufB = new Buffer(BUF_SIZE);
+    var bufA = Buffer.alloc(BUF_SIZE);
+    var bufB = Buffer.alloc(BUF_SIZE);
     var readA = 1;
     var readB = 1;
     while (readA > 0) {

--- a/test/test.js
+++ b/test/test.js
@@ -36,7 +36,7 @@ describe('equalFiles', function () {
     });
 
     it('should handle equal content', function () {
-        var buf = new Buffer('File content\n');
+        var buf = Buffer.from('File content\n');
         var writes = [write(fdA, buf), write(fdB, buf)];
         return Q.all(writes).then(function () {
             assert(fileSyncCmp.equalFiles(pathA, pathB));
@@ -44,8 +44,8 @@ describe('equalFiles', function () {
     });
 
     it('should handle non-equal content', function () {
-        var bufA = new Buffer('Some text\n');
-        var bufB = new Buffer('Other text\n');
+        var bufA = Buffer.from('Some text\n');
+        var bufB = Buffer.from('Other text\n');
         var writes = [write(fdA, bufA), write(fdB, bufB)];
         return Q.all(writes).then(function () {
             assert(!fileSyncCmp.equalFiles(pathA, pathB));


### PR DESCRIPTION
Fixes https://github.com/mgeisler/file-sync-cmp/issues/4

@mgeisler for review please 😃 

Node gives deprecation warnings about old methods

https://nodejs.org/api/buffer.html#buffer_new_buffer_string_encoding

```
└─[$]-> npm run test

> file-sync-cmp@0.1.1 test
> eslint . && mocha



  equalFiles
    ✓ should handle empty files
(node:18527) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
    ✓ should handle equal content
    ✓ should handle non-equal content


  3 passing (12ms)
```
